### PR TITLE
Add `.sh` to installer suffix

### DIFF
--- a/roles/user_install/tasks/main.yml
+++ b/roles/user_install/tasks/main.yml
@@ -19,7 +19,7 @@
   - name: Create temporary file for installer
     ansible.builtin.tempfile:
       state: file
-      suffix: temp
+      suffix: temp.sh
     register: tempfile_1
 
   - name: "download: {{ conda_installer_url }}"


### PR DESCRIPTION
In newer versions of mambaforge install scripts, it actually checks that the script ends with `.sh` (line 16)